### PR TITLE
Fixed materialize.js script src in index.

### DIFF
--- a/templates/starter-template/index.html
+++ b/templates/starter-template/index.html
@@ -119,7 +119,7 @@
 
   <!--  Scripts-->
   <script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
-  <script src="../../bin/materialize.js"></script>
+  <script src="js/materialize.js"></script>
   <script src="js/init.js"></script>
 
   </body>


### PR DESCRIPTION
When someone downloads the starter template from website, they are left with a broken view due to materialize.js script tag pointing to non-existant folder.
